### PR TITLE
fix typos in 'Lape syntax' tutorial (tutorials/5.md)

### DIFF
--- a/tutorials/5.md
+++ b/tutorials/5.md
@@ -169,7 +169,7 @@ var
   BooleanVariable: Boolean;
 
 begin
-  Boolean := True;
+  BooleanVariable := True;
 
   if True then
   begin
@@ -212,10 +212,10 @@ end;
 Repeat Until loops are extremely similar, but take the statement at the end:
 ```pascal
 repeat
-  Writeln('Thsi will loop forever because 1 is always bigger than 0');
+  Writeln('This will only run once as 1 is greater than 0.');
 until 1 > 0;
 ```
-This guarantees type of loops are almost functionally identical to while loops but guarantee that the loop contentes will run at least once:
+This guarantees type of loops are almost functionally identical to while loops but guarantee that the loop contents will run at least once:
 ```pascal
 BooleanVariable := False;
 
@@ -223,7 +223,7 @@ while BooleanVariable then
   Writeln('This will never run because BooleanVariable is False'); 
 
 repeat
-  Writeln('Thsi will run once because the statement is only asked after this was run.');
+  Writeln('This will run once because the statement is only asked after this was run.');
   Writeln('also, repeat/until function as a code block and you can do several lines without being/end');
 until BooleanVariable; 
 ```
@@ -417,7 +417,7 @@ begin
   Writeln(IntArray); //This will print: [5, 2, 3, 7]
 end.
 ```
-I don't know very well how to explain why, but the way I understand it is that when you use the `in` keyword you are not actually using the variable in the array but a copy of it istead.
+I don't know very well how to explain why, but the way I understand it is that when you use the `in` keyword you are not actually using the variable in the array but a copy of it instead.
 So functionally it sort of works like this in the background:
 ```pascal
 var


### PR DESCRIPTION
Fixed typos in explanations, comments, code block